### PR TITLE
Update Makefile

### DIFF
--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -91,7 +91,7 @@ SharedSupport.dmg : InstallAssistant.pkg $(XAR)
 	touch $@
 
 InstallAssistant.pkg :
-	../../fetch-macOS.py --version 11.0.1
+	../../fetch-macOS.py --version 11.1
 
 xar/xar/src/xar : xar/
 	cd xar/xar && ./autogen.sh


### PR DESCRIPTION
Update Makefile to point to the latest OSX version as 11.0.1 returns not found now and 11.1 installs fine.